### PR TITLE
feat: Add support for Embark 4

### DIFF
--- a/embark.json
+++ b/embark.json
@@ -14,6 +14,7 @@
     "ipfs-api": "17.2.4"
   },
   "plugins": {
+    "embarkjs-connector-web3": {}
   },
   "options": {
     "solc": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,11 @@
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
       "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
     },
+    "embarkjs-connector-web3": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/embarkjs-connector-web3/-/embarkjs-connector-web3-4.0.0.tgz",
+      "integrity": "sha512-mqLDRGawEfyqXgoSb2NgTwhlbAHwDrk7eyHrtEvywWgKfEPer+S+5IN+KGXi85d7QxcNKJSZ+BHve8wvWX0FfQ=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {},
   "dependencies": {
     "dateformat": "^3.0.3",
+    "embarkjs-connector-web3": "^4.0.0",
     "react": "^16.4.2",
     "react-dom": "^16.4.2"
   }


### PR DESCRIPTION
Add support for Embark 4 by adding the `embarkjs-connector-web3` plugin to the dapp.